### PR TITLE
Update gui_ping_wheel.lua

### DIFF
--- a/gui_ping_wheel.lua
+++ b/gui_ping_wheel.lua
@@ -289,7 +289,7 @@ function widget:MousePress(mx, my, button)
         -- functionality of mouse build spacing is put in here, sigh
         -- check if alt is pressed
         local alt, ctrl, meta, shift = spGetModKeyState()
-        if (button == 4 or button == 5) and alt then
+        if (button == 4 or button == 5) and (alt or shift) then
             if button == 4 then
                 Spring.SendCommands("buildspacing inc")
             elseif button == 5 then


### PR DESCRIPTION
This tiny edit fixes issue when building while holding just shift, without alt. This is handy when building mines, or even some towers that you don't necessarily want in square shape.